### PR TITLE
Bump uuid from 13.0.0 to 14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "uuid": "13.0.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "eslint": "8.57.1",


### PR DESCRIPTION
Triggered by security [vulnerability report](https://github.com/waldbaer/node-red-persistent-values/security/dependabot/2)